### PR TITLE
adds auto-cc from Prow Github Action

### DIFF
--- a/.github/workflows/knative-auto-cc.yaml
+++ b/.github/workflows/knative-auto-cc.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Auto assign reviewers to PR"
+
+on: 
+  issue_comment
+
+jobs:
+
+  pr_commented:
+    name: Pull Reqest Comment
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: "Prow Github Actions (pga) PR comment"
+        env:
+            NUMBER: ${{ github.event.issue.number }}
+            REPO_OAUTH_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+        uses: docker://ghcr.io/cncf-infra/prow-github-action:latest
+
+      - name: "Capture filtered github action env vars and event.json for pga dev and test"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "gha-runtime-info"
+          path: ${{ github.workspace }}


### PR DESCRIPTION
Adds a Prow Github Action to test the auto-cc command from the blunderbuss plugin. 